### PR TITLE
Fix font import through postMessage

### DIFF
--- a/dev/js/_functions.js
+++ b/dev/js/_functions.js
@@ -86,7 +86,7 @@
 			return '\n\nOh Noes!\nUnless you specifically saved your Glyphr Project, all your progress will be lost.\n\n';
 		} else {
 			return;
-		}		
+		}
 	}
 
 //-------------------
@@ -376,7 +376,7 @@ function saveFile(fname, buffer, ftype) {
 	function isval(val){
 		if(val === 0) return true;
 		else if (val === false) return true;
-		else if (JSON.stringify(val) === '{}') return false;
+		else if ( typeof val === 'object' && Object.keys(val).length === 0 ) return false;
 		else return !!val;
 
 		//return ((typeof val !== "undefined") && (val !== null));

--- a/dev/js/page_openproject.js
+++ b/dev/js/page_openproject.js
@@ -99,7 +99,7 @@
 		contentload.style.display = 'none';
 		contentexamples.style.display = 'none';
 		// contentrecent.style.display = 'none';
-		
+
 		tabnew.style.borderBottomColor = 'rgb(229,234,239)';
 		tabload.style.borderBottomColor = 'rgb(229,234,239)';
 		tabexamples.style.borderBottomColor = 'rgb(229,234,239)';
@@ -178,8 +178,15 @@
 	}
 
 	function handleMessage(evt) {
-		_UI.droppedFileContent = evt.data;
-		ioSVG_importSVGfont(false);
+		// assume strings are SVG fonts
+		if ( typeof evt.data === 'string' ) {
+			_UI.droppedFileContent = evt.data;
+			ioSVG_importSVGfont(false);
+
+		// assume array buffers are otf fonts
+		} else if ( evt.data instanceof ArrayBuffer )  {
+			ioOTF_importOTFfont(false, evt.data);
+		}
 	}
 
 	function handleDragOver(evt) {


### PR DESCRIPTION
This fixes font export form Prototypo to Glyphr-Studio and also allows passing otf fonts as ArrayBuffer (yay opentype.js).
I just noticed my editor made cosmetic changes to the source as well. Let me know if this bothers you.

To make Glyphr-Studio really usable for Prototypo users, bug #203 will have to be investigated though.

Thank you in advance : )