### PR TITLE
fixed non auto-wide unexpected token error

### DIFF
--- a/dev/js/panel_attributes_glyph.js
+++ b/dev/js/panel_attributes_glyph.js
@@ -184,7 +184,7 @@
 					if(!sc.isautowide){
 						content += '<input type="number" id="charaw" step="'+svc+'" '+
 						'value="' + round(sc.glyphwidth, 3) + '" '+
-						'onchange="_UI.focuselement=this.id; getSelectedWorkItem().glyphwidth = (this.value*1); redraw({calledby:{calledby:\'glyphDetails}\'});">';
+						'onchange="_UI.focuselement=this.id; getSelectedWorkItem().glyphwidth = (this.value*1); redraw({calledby:{calledby:\'glyphDetails\'}});">';
 					} else {
 						content += '<input type="number" disabled="disabled" '+
 						'value="'+ round(sc.glyphwidth, 3) + '"/>';


### PR DESCRIPTION
An `Uncaught SyntaxError: Unexpected token )` was being thrown when trying to manually resize character width in chrome. There was a missplace quotation mark when the onchange action was being generated for the number field.