### PR TITLE
fixed email link

### DIFF
--- a/dev/js/framework_nav.js
+++ b/dev/js/framework_nav.js
@@ -534,7 +534,7 @@
 					'<div class="navtargeticon">'+makeIcon({'name':'nav_help', 'color':iconcolor, 'hovercolor':false, 'size':50, 'width':24, 'height':24})+'</div>'+
 					'help</a>';
 			} else if (navarr[i] === 'email'){
-				newsub += ('<a href="mailto:mail@glyphrstudio.com&subject=Hi%20Glyphr%20Studio&body='+genEmailContent()+'" target="_blank" class="navpanellink">email the glyphr studio team</a><br>');
+				newsub += ('<a href="mailto:mail@glyphrstudio.com?subject=Hi%20Glyphr%20Studio&amp;body='+genEmailContent()+'" target="_blank" class="navpanellink">email the glyphr studio team</a><br>');
 			} else if (navarr[i] === 'feature'){
 				newsub += ('<a href="http://glyphrstudio.uservoice.com" class="navpanellink" target="_blank">suggest a feature or improvement</a><br>');
 			} else if (navarr[i] === 'issue'){


### PR DESCRIPTION
The 'email the glyphr studio team' link was spitting out garbage text as so:

![email link broken](https://cloud.githubusercontent.com/assets/8182831/16057255/3a292584-3247-11e6-9830-74ee23a67c63.png)

Now it works as intended!

![fixed email link](https://cloud.githubusercontent.com/assets/8182831/16057341/ae469bc2-3247-11e6-95c8-d67eb44b8083.png)
