### PR TITLE
Fix an issue where the export failed

### DIFF
--- a/dev/js/obj_path.js
+++ b/dev/js/obj_path.js
@@ -549,7 +549,7 @@
 		otpath = otpath || new opentype.Path();
 		var p1, p2;
 
-		if(!this.pathpoints) {
+		if(!this.pathpoints || this.pathpoints.length == 0) {
 			otpath.close();
 			return otpath;
 		}


### PR DESCRIPTION
When editing a font and exporting it I received a crash after the 2nd glyph.

Looking at the code it indicated that it was trying to do something with the pathpoints array.  The array was empty and thus a crash occurred.

I added a line to jump out of the routine if the array is empty.

Not sure if this is the right way to fix but it allowed the export to continue.  Happy to DM the project file if you want to fix another way.